### PR TITLE
Fix build failure in Ruby 3.2 and above

### DIFF
--- a/ios/Classes/ReadDotEnv.rb
+++ b/ios/Classes/ReadDotEnv.rb
@@ -12,9 +12,9 @@ def read_dot_env(envs_root)
   
   puts "going to read env file from root folder #{envs_root}"
 
-  if File.exists?("#{envs_root}../.envfile")
+  if File.exist?("#{envs_root}../.envfile")
     envFilePath = "#{envs_root}../.envfile"
-  elsif File.exists?("#{envs_root}/.envfile")
+  elsif File.exist?("#{envs_root}/.envfile")
     envFilePath = "#{envs_root}.envfile"
   end
   # pick a custom env file if set


### PR DESCRIPTION
`File.exists?` was deprecated and has been removed in Ruby 3.2 and above. This PR replaces the two occurrences of it with `File.exist?` which is already used elsewhere in ReadDotEnv.rb.