### PR TITLE
fix: add namespace to support AGP 8.0.0+

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -25,6 +25,7 @@ apply plugin: 'com.android.library'
 apply plugin: 'kotlin-android'
 
 android {
+    namespace 'com.chaunguyen.flutter_config_plus' 
     compileSdkVersion 33
 
     compileOptions {


### PR DESCRIPTION
Hey! 👋
The package needs to add a `namespace` in order to support projects using Gradle 8+.

Without that, it throws the following error:
![image](https://github.com/user-attachments/assets/279f8ded-f094-45a4-b1ad-bc87a57600b8)

Documentation here:
- https://developer.android.com/build/configure-app-module#groovy
- https://developer.android.com/build/releases/past-releases/agp-8-0-0-release-notes#namespace-dsl